### PR TITLE
Makes "toggle darkness" hide lighting elements and adds some internal Plane constants cleanup

### DIFF
--- a/src/misc/appearance.ts
+++ b/src/misc/appearance.ts
@@ -187,7 +187,7 @@ export namespace Appearance {
 	 * Used to determine if the appearance belongs to a plane that should be invisible when darkness is toggled off. Without darkness there's no reason to see sprites
 	 * that exist to be an alpha mask of the dark.
 	 * @param plane of the appearance as a number
-	 * @returns TRUE or FALSE depending
+	 * @returns TRUE if the plane value falls within the range of Byond lighting planes, FALSE if the plane is anything else
 	 */
 	export function is_lighting_plane(plane : number): boolean {
 		return (plane >= Planes.EMISSIVE_BLOCKER_PLANE && plane <= Planes.O_LIGHTING_VISUAL_PLANE)

--- a/src/misc/appearance.ts
+++ b/src/misc/appearance.ts
@@ -1,5 +1,5 @@
 import { IconStateDir } from "../player/rendering/icon";
-import { RESET_ALPHA, RESET_COLOR, RESET_TRANSFORM } from "./constants";
+import { Planes, RESET_ALPHA, RESET_COLOR, RESET_TRANSFORM } from "./constants";
 import { Matrix, matrix_invert, matrix_is_identity, matrix_multiply } from "./matrix";
 
 export enum FilterType {
@@ -176,11 +176,21 @@ export type TransitionalAppearance = BaseAppearance<TransitionalAppearance|Appea
 export namespace Appearance {
 	const empty_arr : [] = [];
 	export function resolve_plane(plane : number, parent_plane = 0) : number {
-		if(parent_plane < -10000 || parent_plane > 10000) parent_plane = resolve_plane(parent_plane);
-		if(plane < -10000 || plane > 10000) {
+		if(parent_plane < Planes.LOWEST_EVER_PLANE || parent_plane > Planes.HIGHEST_EVER_PLANE) parent_plane = resolve_plane(parent_plane);
+		if(plane < Planes.LOWEST_EVER_PLANE || plane > Planes.HIGHEST_EVER_PLANE) {
 			plane = ((parent_plane + plane + 32767) << 16) >> 16;
 		}
 		return plane;
+	}
+
+	/**
+	 * Used to determine if the appearance belongs to a plane that should be invisible when darkness is toggled off. Without darkness there's no reason to see sprites
+	 * that exist to be an alpha mask of the dark.
+	 * @param plane of the appearance as a number
+	 * @returns TRUE or FALSE depending
+	 */
+	export function is_lighting_plane(plane : number): boolean {
+		return (plane >= Planes.EMISSIVE_BLOCKER_PLANE && plane <= Planes.O_LIGHTING_VISUAL_PLANE)
 	}
 
 	export function get_appearance_parts(appearance : Appearance) {
@@ -261,7 +271,7 @@ export namespace Appearance {
 			clone();
 			overlay.blend_mode = appearance.blend_mode;
 		}
-		if(overlay.plane < -10000 || overlay.plane > 10000) {
+		if(overlay.plane < Planes.LOWEST_EVER_PLANE || overlay.plane > Planes.HIGHEST_EVER_PLANE) {
 			clone();
 			overlay.plane = resolve_plane(overlay.plane, appearance.plane);
 		}

--- a/src/misc/constants.ts
+++ b/src/misc/constants.ts
@@ -39,7 +39,7 @@ export const MAX_LAYER : number = 32;
 
 ///All relevant planes used by Yogstation categorized into an enum of their values
 export const enum Planes{
-    LOWEST_EVER_PLANE = -100,
+    LOWEST_EVER_PLANE = -10000,
     CLICKCATCHER_PLANE = -99,
     SPACE_PLANE = -95,
     FLOOR_PLANE = -2,
@@ -53,7 +53,7 @@ export const enum Planes{
     FLOOR_OPENSPACE_PLANE = 17,
     BYOND_LIGHTING_PLANE = 18,
     CAMERA_STATIC_PLANE = 19,
-    HIGHEST_EVER_PLANE = 110,
+    HIGHEST_EVER_PLANE = 10000,
 }
 
 export const enum SeeInvisibility{

--- a/src/misc/constants.ts
+++ b/src/misc/constants.ts
@@ -35,3 +35,22 @@ export const SOUND_STREAM = 4;
 export const SOUND_UPDATE = 16;
 
 export const MAX_LAYER : number = 32;
+
+///All relevant planes used by Yogstation categorized into an enum of their values
+export const enum Planes{
+    LOWEST_EVER_PLANE = -100,
+    CLICKCATCHER_PLANE = -99,
+    SPACE_PLANE = -95,
+    FLOOR_PLANE = -2,
+    GAME_PLANE = -1,
+    BLACKNESS_PLANE = 0,
+    EMISSIVE_BLOCKER_PLANE = 12,
+    EMISSIVE_PLANE = 13,
+    EMISSIVE_UNBLOCKABLE_PLANE = 14,
+    LIGHTING_PLANE = 15,
+    O_LIGHTING_VISUAL_PLANE = 16,
+    FLOOR_OPENSPACE_PLANE = 17,
+    BYOND_LIGHTING_PLANE = 18,
+    CAMERA_STATIC_PLANE = 19,
+    HIGHEST_EVER_PLANE = 110,
+}

--- a/src/parser/binary_parser.ts
+++ b/src/parser/binary_parser.ts
@@ -1,5 +1,5 @@
 import { Filter, FilterType, ReaderAppearance } from "../misc/appearance";
-import { SOUND_MUTE, SOUND_PAUSED, SOUND_STREAM, SOUND_UPDATE } from "../misc/constants";
+import { Planes, SOUND_MUTE, SOUND_PAUSED, SOUND_STREAM, SOUND_UPDATE } from "../misc/constants";
 import { Matrix } from "../misc/matrix";
 import { DemoParser, ReaderDemoAnimation, ReaderDemoAnimationFrame } from "./base_parser";
 import { RevData } from "./interface";
@@ -549,7 +549,7 @@ export class DemoParserBinary extends DemoParser {
 				appearance.vis_flags = p.read_uint8();
 			}
 
-			if(appearance.plane == 15 && !appearance.screen_loc) appearance.blend_mode = 4; // This only exists because I CBA to implement plane masters right now
+			if(appearance.plane == Planes.LIGHTING_PLANE && !appearance.screen_loc) appearance.blend_mode = 4; // This only exists because I CBA to implement plane masters right now
 			return this.appearance_refs[appearance_ref] = this.appearance_id(appearance);
 		} else {
 			if(appearance_ref == 0xFFFF) return null;

--- a/src/parser/text_parser.ts
+++ b/src/parser/text_parser.ts
@@ -1,6 +1,7 @@
 import { normalize_ref } from "../misc/ref";
 import { ReaderAppearance } from "../misc/appearance";
 import { DemoParser } from "./base_parser";
+import { Planes } from "../misc/constants";
 
 const MIN_VERSION = 1;
 const MAX_VERSION = 1;
@@ -247,7 +248,7 @@ export class DemoParserText extends DemoParser {
 			icon_state: `${(((x + y) ^ ~(x * y) + z) % 25 + 25) % 25}`,
 			name: 'space',
 			layer: 1.8,
-			plane: -95
+			plane: Planes.SPACE_PLANE,
 		};
 	}
 
@@ -267,7 +268,7 @@ export class DemoParserText extends DemoParser {
 				icon_state: '1',
 				name: 'space',
 				layer: 1.8,
-				plane: -95
+				plane: Planes.SPACE_PLANE
 			};
 			if(p.curr() == 't') {
 				p.idx++;
@@ -356,7 +357,7 @@ export class DemoParserText extends DemoParser {
 		if(p.read_next_or_end()) return appearance;
 		if(p.curr() != ';') {
 			appearance.plane = p.read_number();
-			if(appearance.plane == 15) appearance.blend_mode = 4;
+			if(appearance.plane == Planes.LIGHTING_PLANE) appearance.blend_mode = 4;
 			else appearance.blend_mode = 0;
 		}
 		if(p.read_next_or_end()) return appearance;
@@ -429,7 +430,7 @@ export class DemoParserText extends DemoParser {
 				p.idx++;
 				if(p.curr() == ']') break;
 				let overlay = this.read_appearance(p, appearance, false);
-				//if(overlay?.plane == 15) continue;
+				//if(overlay?.plane == Planes.LIGHTING_PLANE) continue;
 				if(overlay) appearance.underlays.push(this.appearance_id(overlay));
 			}
 			if(p.curr() == '[' && !appearance.underlays.length) p.idx++;

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -9,7 +9,7 @@ import { AtlasNode, DmiAtlas } from "./rendering/atlas";
 import { IconState, IconStateDir } from "./rendering/icon";
 import { CmdViewport, FollowDesc, RenderingCmd } from "./rendering/commands";
 import { DrawBuffer } from "./rendering/buffer";
-import { LONG_GLIDE, RESET_ALPHA, RESET_COLOR, RESET_TRANSFORM, SEE_MOBS, SEE_OBJS, SEE_THRU, SEE_TURFS } from "../misc/constants";
+import { LONG_GLIDE, Planes, RESET_ALPHA, RESET_COLOR, RESET_TRANSFORM, SEE_MOBS, SEE_OBJS, SEE_THRU, SEE_TURFS } from "../misc/constants";
 import { matrix_is_identity, matrix_multiply } from "../misc/matrix";
 import { despam_promise } from "../misc/promise_despammer";
 import { view_turfs } from "./view";
@@ -452,7 +452,7 @@ export class DemoPlayer {
 			}
 			let root_appearance = thing.get_appearance(this, see_invisible);
 			if(!root_appearance || root_appearance.invisibility > see_invisible) continue;
-			if(root_appearance.plane == 15 && !this.show_darkness) continue;
+			if(Appearance.is_lighting_plane(root_appearance.plane) && !this.show_darkness) continue;
 			for(let appearance of Appearance.get_appearance_parts(root_appearance)) {
 				if(!appearance.icon_state_dir) {
 					let dir = this.get_appearance_dir(appearance, buffer.atlas);


### PR DESCRIPTION
Dynamic lighting currently breaks the replay viewer because it doesn't have the behavior to turn the lighting sprites into an alpha mask for darkness. This is a bit of a bandaid fix so that we can toggle off the overly bright orbs in the replay until we update the viewer to handle the filters for masking.

tested with Fulp's dynamic lighting that is currently shaping up to break replays for a while

https://github.com/yogstation13/demo-viewer/assets/46236974/d4999f1b-7290-4dcf-b8ca-e439baf9c697

