### PR TITLE
Bump deployment task target from ubuntu-18.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
ubuntu-18.04 is deprecated by github so it no longer has any dedicated task runners. switching to latest as the target should ensure we don't encounter this issue in the future
![image](https://github.com/yogstation13/demo-viewer/assets/46236974/183b8040-11e3-4365-a75d-925340405217)
