### PR TITLE
Adds "global" chat message targets

### DIFF
--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -788,7 +788,7 @@ export class DemoPlayer {
 			let frame = this.frames[i];
 			if(!frame.chat) continue;
 			for(let chat of frame.chat) {
-				if(chat.clients.includes(target) || chat.clients.includes("world")) {
+				if(chat.clients.includes("world") || chat.clients.includes(target == undefined ? "global" : target)) {
 					messages.push({
 						message: chat.message,
 						frame_index: i,


### PR DESCRIPTION
This allows chat messages to set their target as `global` - so it'll appear in the "main" targetless chat window. This makes it so OOC messages, deadchat, and admin announces can be seen without having to find an observer's client and go through their chat manually

DM-side implementation here: https://github.com/Monkestation/Monkestation2.0/pull/4771